### PR TITLE
Please modify datatypes to suppress warnings

### DIFF
--- a/rumble-api.yml
+++ b/rumble-api.yml
@@ -1330,11 +1330,11 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         updated_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         organization_id:
@@ -1350,11 +1350,11 @@ components:
           format: boolean
           example: true
         first_seen:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         last_seen:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         detected_by:
@@ -1404,31 +1404,31 @@ components:
             type: string
             example: www
         service_count:
-          type: number
+          type: integer
           format: int64
           example: 10
         service_count_tcp:
-          type: number
+          type: integer
           format: int64
           example: 7
         service_count_udp:
-          type: number
+          type: integer
           format: int64
           example: 1
         service_count_arp:
-          type: number
+          type: integer
           format: int64
           example: 1
         service_count_icmp:
-          type: number
+          type: integer
           format: int64
           example: 1
         lowest_ttl:
-          type: number
+          type: integer
           format: int64
           example: 0
         lowest_rtt:
-          type: number
+          type: integer
           format: int64
           example: 1
         last_agent_id:
@@ -1447,7 +1447,7 @@ components:
           type: string
           example: Intel Corporate
         newest_mac_age:
-          type: number
+          type: integer
           format: int64
           example: 1304035200000000000
         comments:
@@ -1522,11 +1522,11 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         service_created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         service_updated_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         service_address:
@@ -1539,7 +1539,7 @@ components:
           type: string
           example: www
         service_port:
-          type: number
+          type: string
           format: port
           example: 80
         service_data:
@@ -1563,11 +1563,11 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         updated_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         organization_id:
@@ -1583,11 +1583,11 @@ components:
           format: boolean
           example: true
         first_seen:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         last_seen:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         detected_by:
@@ -1637,31 +1637,31 @@ components:
             type: string
             example: CORPNET
         service_count:
-          type: number
+          type: integer
           format: int64
           example: 10
         service_count_tcp:
-          type: number
+          type: integer
           format: int64
           example: 7
         service_count_udp:
-          type: number
+          type: integer
           format: int64
           example: 1
         service_count_arp:
-          type: number
+          type: integer
           format: int64
           example: 1
         service_count_icmp:
-          type: number
+          type: integer
           format: int64
           example: 1
         lowest_ttl:
-          type: number
+          type: integer
           format: int64
           example: 0
         lowest_rtt:
-          type: number
+          type: integer
           format: int64
           example: 1
         last_agent_id:
@@ -1680,7 +1680,7 @@ components:
           type: string
           example: Intel Corporate
         newest_mac_age:
-          type: number
+          type: integer
           format: int64
           example: 1304035200000000000
         comments:
@@ -1751,11 +1751,11 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         updated_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         permanent:
@@ -1784,11 +1784,11 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         last_seen:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         organization_id:
@@ -1866,11 +1866,11 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         updated_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         client_id:
@@ -1881,7 +1881,7 @@ components:
           type: string
           example: DT11226D9EEEA2B035D42569585900
         download_token_created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         permanent:
@@ -1897,49 +1897,49 @@ components:
           type: boolean
           example: false
         deactivated_at:
-          type: number
+          type: integer
           format: int64
           example: 0
         service_count:
-          type: number
+          type: integer
           format: int64
           example: 10
         service_count_tcp:
-          type: number
+          type: integer
           format: int64
           example: 7
         service_count_udp:
-          type: number
+          type: integer
           format: int64
           example: 1
         service_count_arp:
-          type: number
+          type: integer
           format: int64
           example: 1
         service_count_icmp:
-          type: number
+          type: integer
           format: int64
           example: 1
         asset_count:
-          type: number
+          type: integer
           format: int64
           example: 100
         export_token:
           type: string
           example: ET11226D9EEEA2B035D42569585900
         export_token_created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         export_token_last_used_at:
-          type: number
+          type: integer
           format: int64
           example: 0
         export_token_last_used_by:
           type: string
           example: 127.0.0.1
         export_token_counter:
-          type: number
+          type: integer
           format: int64
           example: 0
 
@@ -1961,7 +1961,7 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         created_by:
@@ -1972,7 +1972,7 @@ components:
           type: string
           example: API key used for Splunk integration
         last_used_at:
-          type: number
+          type: integer
           format: int64
           example: 0
         last_used_ip:
@@ -1982,15 +1982,15 @@ components:
           type: string
           example: "curl/7.44.1"
         counter:
-          type: number
+          type: integer
           format: int64
           example: 1
         usage_today:
-          type: number
+          type: integer
           format: int64
           example: 100
         usage_limit:
-          type: number
+          type: integer
           format: int64
           example: 10000
         token:
@@ -2018,11 +2018,11 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         updated_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         host_id:
@@ -2041,7 +2041,7 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         last_checkin:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         os:
@@ -2069,7 +2069,7 @@ components:
           type: boolean
           example: false
         deactivated_at:
-          type: number
+          type: integer
           format: int64
           example: 0
 
@@ -2109,7 +2109,7 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         created_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         created_by:
@@ -2121,7 +2121,7 @@ components:
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         updated_at:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         type:


### PR DESCRIPTION
Per [OpenAPI Data Types](https://swagger.io/docs/specification/data-models/data-types/#numbers) `int64` and `port` are not valid formats for type `number`. As a result it generated a bunch of warnings when creating a client stub using OpenAPI generator.

`[main] WARN  o.o.codegen.DefaultCodegen - Unknown format int64 detected for type number. Defaulting to number`

`[main] WARN  o.o.codegen.DefaultCodegen - Unknown format port detected for type number. Defaulting to number`

Cheers