### PR TITLE
Apply security to individual API operations and modify the datatypes.

### DIFF
--- a/rumble-api.yml
+++ b/rumble-api.yml
@@ -64,6 +64,8 @@ paths:
 
   /export/org/assets.json:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsJSON
@@ -89,6 +91,8 @@ paths:
 
   /export/org/assets.jsonl:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsJSONL
@@ -114,6 +118,8 @@ paths:
 
   /export/org/assets.csv:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsCSV
@@ -138,6 +144,8 @@ paths:
 
   /export/org/assets.nmap.xml:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsNmapXML
@@ -162,6 +170,8 @@ paths:
 
   /export/org/assets/sync/created/assets.json:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetSyncCreatedJSON
@@ -178,7 +188,7 @@ paths:
           description: an optional unix timestamp to use as a checkpoint
           required: false
           schema:
-            type: number
+            type: integer
             format: int64
             example: 1576300370
       responses:
@@ -193,6 +203,8 @@ paths:
 
   /export/org/assets/sync/updated/assets.json:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetSyncUpdatedJSON
@@ -209,7 +221,7 @@ paths:
           description: an optional unix timestamp to use as a checkpoint
           required: false
           schema:
-            type: number
+            type: integer
             format: int64
             example: 1576300370
       responses:
@@ -224,6 +236,8 @@ paths:
 
   /export/org/services.json:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportServicesJSON
@@ -249,6 +263,8 @@ paths:
 
   /export/org/services.jsonl:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportServicesJSONL
@@ -274,6 +290,8 @@ paths:
 
   /export/org/services.csv:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportServicesCSV
@@ -299,6 +317,8 @@ paths:
 
   /export/org/sites.json:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportSitesJSON
@@ -317,6 +337,8 @@ paths:
 
   /export/org/sites.jsonl:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId:  exportSitesJSONL
@@ -335,6 +357,8 @@ paths:
 
   /export/org/sites.csv:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId:  exportSitesCSV
@@ -353,6 +377,8 @@ paths:
 
   /export/org/wireless.json:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportWirelessJSON
@@ -378,6 +404,8 @@ paths:
 
   /export/org/wireless.jsonl:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportWirelessJSONL
@@ -403,6 +431,8 @@ paths:
 
   /export/org/wireless.csv:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Export
       operationId: exportWirelessCSV
@@ -427,6 +457,8 @@ paths:
 
   /org:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getOrganization
@@ -441,6 +473,8 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     patch:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: updateOrganization
@@ -465,6 +499,8 @@ paths:
 
   /org/key:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getKey
@@ -481,6 +517,8 @@ paths:
 
   /org/agents:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getAgents
@@ -499,6 +537,8 @@ paths:
 
   /org/agents/{agent_id}:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getAgent
@@ -523,6 +563,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: removeAgent
@@ -543,6 +585,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     patch:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: updateAgentSite
@@ -576,6 +620,8 @@ paths:
 
   /org/agents/{agent_id}/update:
     post:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: upgradeAgent
@@ -598,6 +644,8 @@ paths:
 
   /org/sites:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getSites
@@ -614,6 +662,8 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     put:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: createSite
@@ -639,6 +689,8 @@ paths:
 
   /org/sites/{site_id}:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getSite
@@ -663,6 +715,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: removeSite
@@ -683,6 +737,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     patch:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: updateSite
@@ -716,6 +772,8 @@ paths:
 
   /org/sites/{site_id}/import:
     put:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: importScanData
@@ -752,6 +810,8 @@ paths:
 
   /org/sites/{site_id}/scan:
     put:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: createScan
@@ -787,6 +847,8 @@ paths:
 
   /org/assets:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getAssets
@@ -812,6 +874,8 @@ paths:
 
   /org/assets/{asset_id}:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getAsset
@@ -836,6 +900,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: removeAsset
@@ -858,6 +924,8 @@ paths:
 
   /org/assets/{asset_id}/comments:
     patch:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: updateAssetComments
@@ -891,6 +959,8 @@ paths:
 
   /org/assets/{asset_id}/tags:
     patch:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: updateAssetTags
@@ -924,6 +994,8 @@ paths:
 
   /org/services:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getServices
@@ -949,6 +1021,8 @@ paths:
 
   /org/services/{service_id}:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getService
@@ -973,6 +1047,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: removeService
@@ -995,6 +1071,8 @@ paths:
 
   /org/wireless:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getWirelessLANs
@@ -1020,6 +1098,8 @@ paths:
 
   /org/wirelesss/{wireless_id}:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getWirelessLAN
@@ -1042,6 +1122,8 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     delete:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: removeWirelessLAN
@@ -1065,6 +1147,8 @@ paths:
 
   /org/tasks:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getTasks
@@ -1090,6 +1174,8 @@ paths:
 
   /org/tasks/{task_id}:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getTask
@@ -1112,6 +1198,8 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     patch:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: updateTask
@@ -1145,6 +1233,8 @@ paths:
 
   /org/tasks/{task_id}/data:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getTaskScanData
@@ -1167,6 +1257,8 @@ paths:
 
   /org/tasks/{task_id}/changes:
     get:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: getTaskChangeReport
@@ -1189,6 +1281,8 @@ paths:
 
   /org/tasks/{task_id}/stop:
     post:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: stopTask
@@ -1211,6 +1305,8 @@ paths:
 
   /org/tasks/{task_id}/hide:
     post:
+      security:
+        - bearerAuth: []
       tags:
         - Organization
       operationId: hideTask
@@ -1370,7 +1466,7 @@ components:
         - assets
       properties:
         since:
-          type: number
+          type: integer
           format: int64
           example: 1576300370
         assets:

--- a/rumble-api.yml
+++ b/rumble-api.yml
@@ -64,12 +64,12 @@ paths:
 
   /export/org/assets.json:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsJSON
       summary: Exports the asset inventory.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -91,12 +91,12 @@ paths:
 
   /export/org/assets.jsonl:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsJSONL
       summary: Asset inventory as JSON line-delimited.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -118,12 +118,12 @@ paths:
 
   /export/org/assets.csv:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsCSV
       summary: Asset inventory as CSV.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -144,12 +144,12 @@ paths:
 
   /export/org/assets.nmap.xml:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetsNmapXML
       summary: Asset inventory as Nmap-style XML.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -170,12 +170,12 @@ paths:
 
   /export/org/assets/sync/created/assets.json:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetSyncCreatedJSON
       summary: Exports the asset inventory in a sync-friendly manner using created_at as a checkpoint.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -203,12 +203,12 @@ paths:
 
   /export/org/assets/sync/updated/assets.json:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportAssetSyncUpdatedJSON
       summary: Exports the asset inventory in a sync-friendly manner using updated_at as a checkpoint.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -236,12 +236,12 @@ paths:
 
   /export/org/services.json:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportServicesJSON
       summary: Service inventory as JSON.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -263,12 +263,12 @@ paths:
 
   /export/org/services.jsonl:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportServicesJSONL
       summary: Service inventory as JSON line-delimited.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -290,12 +290,12 @@ paths:
 
   /export/org/services.csv:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportServicesCSV
       summary: Service inventory as CSV.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -317,12 +317,12 @@ paths:
 
   /export/org/sites.json:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportSitesJSON
       summary: Export all sites.
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: all sites
@@ -337,12 +337,12 @@ paths:
 
   /export/org/sites.jsonl:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId:  exportSitesJSONL
       summary: Site list as JSON line-delimited.
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: all sites
@@ -357,12 +357,12 @@ paths:
 
   /export/org/sites.csv:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId:  exportSitesCSV
       summary: Site list as CSV.
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: all sites
@@ -377,12 +377,12 @@ paths:
 
   /export/org/wireless.json:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportWirelessJSON
       summary: Wireless inventory as JSON.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -404,12 +404,12 @@ paths:
 
   /export/org/wireless.jsonl:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportWirelessJSONL
       summary: Wireless inventory as JSON line-delimited.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -431,12 +431,12 @@ paths:
 
   /export/org/wireless.csv:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Export
       operationId: exportWirelessCSV
       summary: Wireless inventory as CSV.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -457,12 +457,12 @@ paths:
 
   /org:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getOrganization
       summary: Get organization details.
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: organization details
@@ -473,12 +473,12 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     patch:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: updateOrganization
       summary: Update organization details.
+      security:
+        - bearerAuth: []
       requestBody:
         description: organization options
         required: true
@@ -499,12 +499,12 @@ paths:
 
   /org/key:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getKey
       summary: Get API key details.
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: api key details
@@ -517,12 +517,12 @@ paths:
 
   /org/agents:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getAgents
       summary: Get all agents.
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: array of agents
@@ -537,12 +537,12 @@ paths:
 
   /org/agents/{agent_id}:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getAgent
       summary: Get details for a single agent.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: agent_id
@@ -563,12 +563,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: removeAgent
       summary: Remove and uninstall an agent.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: agent_id
@@ -585,12 +585,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     patch:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: updateAgentSite
       summary: Update the site associated with agent.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: agent_id
@@ -620,12 +620,12 @@ paths:
 
   /org/agents/{agent_id}/update:
     post:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: upgradeAgent
       summary: Force an agent to update and restart.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: agent_id
@@ -644,12 +644,12 @@ paths:
 
   /org/sites:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getSites
       summary: Get all sites.
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: array of sites
@@ -662,12 +662,12 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     put:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: createSite
       summary: Create a new site.
+      security:
+        - bearerAuth: []
       requestBody:
         description: site definition
         required: true
@@ -689,12 +689,12 @@ paths:
 
   /org/sites/{site_id}:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getSite
       summary: Get site details.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: site_id
@@ -715,12 +715,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: removeSite
       summary: Remove a site and associated assets.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: site_id
@@ -737,12 +737,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     patch:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: updateSite
       summary: Update a site definition.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: site_id
@@ -772,12 +772,12 @@ paths:
 
   /org/sites/{site_id}/import:
     put:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: importScanData
       summary: Import a scan data file into a site.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: site_id
@@ -810,12 +810,12 @@ paths:
 
   /org/sites/{site_id}/scan:
     put:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: createScan
       summary: Create a scan task for a given site.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: site_id
@@ -847,12 +847,12 @@ paths:
 
   /org/assets:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getAssets
       summary: Get all assets.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -874,12 +874,12 @@ paths:
 
   /org/assets/{asset_id}:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getAsset
       summary: Get asset details.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: asset_id
@@ -900,12 +900,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: removeAsset
       summary: Remove an asset.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: asset_id
@@ -924,12 +924,12 @@ paths:
 
   /org/assets/{asset_id}/comments:
     patch:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: updateAssetComments
       summary: Update asset comments.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: asset_id
@@ -959,12 +959,12 @@ paths:
 
   /org/assets/{asset_id}/tags:
     patch:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: updateAssetTags
       summary: Update asset tags.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: asset_id
@@ -994,12 +994,12 @@ paths:
 
   /org/services:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getServices
       summary: Get all services.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -1021,12 +1021,12 @@ paths:
 
   /org/services/{service_id}:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getService
       summary: Get service details.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: service_id
@@ -1047,12 +1047,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
     delete:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: removeService
       summary: Remove a service.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: service_id
@@ -1071,12 +1071,12 @@ paths:
 
   /org/wireless:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getWirelessLANs
       summary: Get all wireless LANs.
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: search
@@ -1098,12 +1098,12 @@ paths:
 
   /org/wirelesss/{wireless_id}:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getWirelessLAN
       summary: Get wireless LAN details.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: wireless_id
@@ -1122,12 +1122,12 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     delete:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: removeWirelessLAN
       summary: Remove a wireless LAN.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: wireless_id
@@ -1147,12 +1147,12 @@ paths:
 
   /org/tasks:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getTasks
       summary: Get all tasks (last 1000).
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: status
@@ -1174,12 +1174,12 @@ paths:
 
   /org/tasks/{task_id}:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getTask
       summary: Get task details.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: task_id
@@ -1198,12 +1198,12 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     patch:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: updateTask
       summary: Update task parameters.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: task_id
@@ -1233,12 +1233,12 @@ paths:
 
   /org/tasks/{task_id}/data:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getTaskScanData
       summary: Returns a temporary task scan data url.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: task_id
@@ -1257,12 +1257,12 @@ paths:
 
   /org/tasks/{task_id}/changes:
     get:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: getTaskChangeReport
       summary: Returns a temporary task change report data url.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: task_id
@@ -1281,12 +1281,12 @@ paths:
 
   /org/tasks/{task_id}/stop:
     post:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: stopTask
       summary: Signal that a task should be stopped or canceled.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: task_id
@@ -1305,12 +1305,12 @@ paths:
 
   /org/tasks/{task_id}/hide:
     post:
-      security:
-        - bearerAuth: []
       tags:
         - Organization
       operationId: hideTask
       summary: Signal that a completed task should be hidden.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: task_id


### PR DESCRIPTION
- The security schemes are defined in the `securitySchemes` section, but they are not applied to individual API operations. 

     **Addition**:
     Added security section to individual operations.

- `int64` is not a valid format for type `number`. 

     **Modification**
     Modified the datatype from `number` to `integer`